### PR TITLE
Adding more languages to extension list

### DIFF
--- a/zed-color-highlight/extension.toml
+++ b/zed-color-highlight/extension.toml
@@ -33,5 +33,18 @@ languages = [
     "Ruby",
     "Python",
     "Go",
+    "C",
+    "C++",
+    "ini",
+    "Shell Script",
+    "Bash",
+    "Fish",
+    "Lua",
+    "Zig",
+    "Makefile",
+    "Make",
+    "Dockerfile",
+    "Markdown",
+    "Plain Text",
 ]
 code_action_kinds = []


### PR DESCRIPTION
  Expands the default language list in the Zed extension to include C, C++, ini, Shell Script, Bash, Fish, Lua, Zig,
  Makefile, Make, Dockerfile, Markdown, and Plain Text.

  This is a short-term improvement while a fully configurable solution (as discussed in #24) is considered.