### PR TITLE
Add note about languages to README

### DIFF
--- a/zed-color-highlight/README.md
+++ b/zed-color-highlight/README.md
@@ -16,6 +16,22 @@ Add the following to your Zed settings:
 }
 ```
 
+Due to a missing feature in the Zed Extension system, it's only enabled by default on a predefined set of languages. (if you want this changed, please upvote the [upstream feature request](https://github.com/zed-industries/zed/discussions/45360))
+
+You can configure Zed to enable ColorLSP on more languages. For example, to enable it on Markdown, you can add to your config:
+
+```jsonc
+{
+  // ...
+  "languages": {
+    "Markdown": {
+      "language-servers": ["...", "color-lsp"],
+    },
+  },
+  // ...
+}
+```
+
 ## License
 
 MIT


### PR DESCRIPTION
In order to reduce the number of users confused by the fact that this only activates on a predefined set of languages, this PR adds a note to the README specific to Zed, including a settings snippet.

Solves #37